### PR TITLE
Some time functions derived from SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.o
 bin/
 Makefile.local
+make.sh
+meins/
+.gitignore
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ AR := $(TOOLCHAIN_PREFIX)ar
 LD := $(TOOLCHAIN_PREFIX)gcc
 OBJCOPY := $(TOOLCHAIN_PREFIX)objcopy
 
-
 XTENSA_LIBS ?= $(shell $(CC) -print-sysroot)
 
 
@@ -38,7 +37,7 @@ CPPFLAGS += -I$(XTENSA_LIBS)/include \
 		-I$(SDK_BASE)/include \
 		-I.
 
-		LDFLAGS  += 	-L$(XTENSA_LIBS)/lib \
+LDFLAGS  += -L$(XTENSA_LIBS)/lib \
 		-L$(XTENSA_LIBS)/arch/lib \
 
 

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,14 @@ OBJ_FILES := \
 	ssl/tls1_svr.o \
 	ssl/x509.o \
 	crypto/crypto_misc.o \
-
+	util/time.o \
 
 CPPFLAGS += -I$(XTENSA_LIBS)/include \
 		-Icrypto \
 		-Issl \
+		-Iutil \
+		-I$(SDK_BASE)/include \
 		-I.
-
 LDFLAGS  += 	-L$(XTENSA_LIBS)/lib \
 		-L$(XTENSA_LIBS)/arch/lib \
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ CPPFLAGS += -I$(XTENSA_LIBS)/include \
 		-Iutil \
 		-I$(SDK_BASE)/include \
 		-I.
-LDFLAGS  += 	-L$(XTENSA_LIBS)/lib \
+
+		LDFLAGS  += 	-L$(XTENSA_LIBS)/lib \
 		-L$(XTENSA_LIBS)/arch/lib \
 
 

--- a/util/time.c
+++ b/util/time.c
@@ -1,0 +1,100 @@
+/*
+ * time.c - ESP8266-specific header for SNTP
+ * Copyright (c) 2015 Peter Dobler. All rights reserved.
+ * This file is part of the esp8266 core for Arduino environment.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+#include "time.h"
+#include "sntp.h"
+
+// time gap in seconds from 01.01.1900 (NTP time) to 01.01.1970 (UNIX time)
+#define DIFF1900TO1970 2208988800UL
+
+// set locals...
+static unsigned long confTimeZone;
+static int confDayLight;
+
+void configTime(unsigned long timezone, int daylight)
+{
+  confTimeZone = timezone;
+  // daylight actual not used
+  confDayLight = daylight;
+  sntp_init();
+  sntp_setservername(0, (char*)"time.nist.gov");
+  sntp_setservername(1, (char*)"time.windows.com");
+  sntp_setservername(2, (char*)"de.pool.ntp.org");
+  sntp_set_timezone(timezone/3600);
+  delay(1000);
+  // we have to wait for sntp
+  unsigned long m_secsSince1900=0;
+  while (!m_secsSince1900)
+  {
+    m_secsSince1900 = sntp_get_current_timestamp();
+    delay(200);
+  }
+  delay(1000);
+
+}
+
+// seconds since 1970
+time_t mktime(struct tm_t *tm) {
+  // system_mktime expects month in range 1..12
+  #define START_MONTH 1
+  return DIFF1900TO1970 + system_mktime(tm->tm_year, tm->tm_mon + START_MONTH, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+}
+
+time_t time(time_t * t)
+{
+  time_t seconds = sntp_get_current_timestamp();
+  if (seconds)
+    *t = seconds;
+  return seconds ;
+}
+
+// The gettimeofday() function is marked obsolescent.
+// Applications should use the clock_gettime() function instead
+// see: http://pubs.opengroup.org/onlinepubs/9699919799/
+int gettimeofday(void *tp, void *tzp)
+{
+  struct timeval tv;
+  tv.tv_sec  = millis() / 1000;
+  tv.tv_usec = micros();
+  ((struct timeval*)tp)->tv_sec  = tv.tv_sec;
+  ((struct timeval*)tp)->tv_usec = tv.tv_usec;
+  return 0;
+}
+
+int clock_gettime(clockid_t clock_id, struct timespec *tp)
+{
+  struct timespec tv;
+  tv.tv_sec  = millis() / 1000;
+  tv.tv_nsec = micros() * 1000L;
+  ((struct timespec*)tp)->tv_sec  = tv.tv_sec;
+  ((struct timespec*)tp)->tv_nsec = tv.tv_nsec;
+  return 0;
+}
+
+char * ctime(const time_t *clock)
+{
+  return sntp_get_real_time(*clock);
+}
+
+int compareTime(struct tm_t *tm1, struct tm_t *tm2)
+{
+  unsigned long sec1 = mktime(tm1);
+  unsigned long sec2 = mktime(tm2);
+  return (sec1 - sec2);
+}
+

--- a/util/time.c
+++ b/util/time.c
@@ -69,8 +69,8 @@ time_t time(time_t * t)
 int gettimeofday(void *tp, void *tzp)
 {
   struct timeval tv;
-  tv.tv_sec  = millis() / 1000;
-  tv.tv_usec = micros();
+  tv.tv_sec  = system_get_time() / 1000000;
+  tv.tv_usec = system_get_time() % 1000000;
   ((struct timeval*)tp)->tv_sec  = tv.tv_sec;
   ((struct timeval*)tp)->tv_usec = tv.tv_usec;
   return 0;
@@ -80,7 +80,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
 {
   struct timespec tv;
   tv.tv_sec  = millis() / 1000;
-  tv.tv_nsec = micros() * 1000L;
+  tv.tv_nsec = micros() * 1000;
   ((struct timespec*)tp)->tv_sec  = tv.tv_sec;
   ((struct timespec*)tp)->tv_nsec = tv.tv_nsec;
   return 0;

--- a/util/time.c
+++ b/util/time.c
@@ -1,5 +1,5 @@
 /*
- * time.c - ESP8266-specific header for SNTP
+ * time.c - ESP8266-specific functions for SNTP
  * Copyright (c) 2015 Peter Dobler. All rights reserved.
  * This file is part of the esp8266 core for Arduino environment.
  * This library is free software; you can redistribute it and/or
@@ -49,16 +49,16 @@ void configTime(unsigned long timezone, int daylight)
 }
 
 // seconds since 1970
-time_t mktime(struct tm_t *tm) {
+time_t mktime(struct tm *t) {
   // system_mktime expects month in range 1..12
   #define START_MONTH 1
-  return DIFF1900TO1970 + system_mktime(tm->tm_year, tm->tm_mon + START_MONTH, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+  return DIFF1900TO1970 + system_mktime(t->tm_year, t->tm_mon + START_MONTH, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
 }
 
 time_t time(time_t * t)
 {
   time_t seconds = sntp_get_current_timestamp();
-  if (seconds)
+  if (t)
     *t = seconds;
   return seconds ;
 }
@@ -91,10 +91,10 @@ char * ctime(const time_t *clock)
   return sntp_get_real_time(*clock);
 }
 
-int compareTime(struct tm_t *tm1, struct tm_t *tm2)
+int compareTime(struct tm *t1, struct tm *t2)
 {
-  unsigned long sec1 = mktime(tm1);
-  unsigned long sec2 = mktime(tm2);
+  unsigned long sec1 = mktime(t1);
+  unsigned long sec2 = mktime(t2);
   return (sec1 - sec2);
 }
 

--- a/util/time.h
+++ b/util/time.h
@@ -1,11 +1,58 @@
 #ifndef TIME_H
 #define TIME_H
 
+typedef long size_t;
+typedef long time_t;
+typedef long clockid_t;
+
+#include "user_interface.h"
+
 struct timeval
 {
   time_t tv_sec;
   long   tv_usec;
 };
 
+struct timespec {
+  time_t tv_sec;   /* Seconds */
+  long   tv_nsec;  /* Nanoseconds */
+};
+
+//*******************************************************************
+
+// time structure represents time A.D. (e.g. year: 2015)
+struct tm_t {
+  int tm_sec;  /* seconds,          range 0 to 59  */
+  int tm_min;  /* minutes,          range 0 to 59  */
+  int tm_hour; /* hours,            range 0 to 23  */
+  int tm_mday; /* day of the month, range 1 to 31  */
+  int tm_mon;  /* month,            range 0 to 11  */
+  int tm_year; /* number of years   since 1900     */
+  int tm_wday; /* day of the week,  range 0 to 6   */ //sunday = 0
+  int tm_yday; /* day in the year,  range 0 to 365 */
+  int tm_isdst;/* daylight saving time             */ //no=0, yes>0
+} tm_t;
+
+struct tm {
+  int tm_sec;  /* seconds,          range 0 to 59  */
+  int tm_min;  /* minutes,          range 0 to 59  */
+  int tm_hour; /* hours,            range 0 to 23  */
+  int tm_mday; /* day of the month, range 1 to 31  */
+  int tm_mon;  /* month,            range 0 to 11  */
+  int tm_year; /* number of years   since 1900     */
+  int tm_wday; /* day of the week,  range 0 to 6   */ //sunday = 0
+  int tm_yday; /* day in the year,  range 0 to 365 */
+  int tm_isdst;/* daylight saving time             */ //no=0, yes>0
+} tm;
+
+time_t mktime(struct tm_t *tm);
+char*  ctime(const time_t *clock);
+int    gettimeofday(void *tp, void *tzp);
+int    clock_gettime(clockid_t clock_id, struct timespec *tp);
+
+void   configTime(unsigned long timezone, int daylight);
+time_t time(time_t * t);
+int    compareTime(struct tm_t *tm1, struct tm_t *tm2);
 
 #endif //TIME_H
+

--- a/util/time.h
+++ b/util/time.h
@@ -1,3 +1,21 @@
+/*
+ * time.h - ESP8266-specific header for SNTP
+ * Copyright (c) 2015 Peter Dobler. All rights reserved.
+ * This file is part of the esp8266 core for Arduino environment.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
 #ifndef TIME_H
 #define TIME_H
 
@@ -51,19 +69,7 @@ struct tm {
   int tm_yday; /* day in the year,  range 0 to 365 */
   int tm_isdst;/* daylight saving time             */ //no=0, yes>0
 };
-#ifdef MMM
-struct tm {
-  int tm_sec;  /* seconds,          range 0 to 59  */
-  int tm_min;  /* minutes,          range 0 to 59  */
-  int tm_hour; /* hours,            range 0 to 23  */
-  int tm_mday; /* day of the month, range 1 to 31  */
-  int tm_mon;  /* month,            range 0 to 11  */
-  int tm_year; /* number of years   since 1900     */
-  int tm_wday; /* day of the week,  range 0 to 6   */ //sunday = 0
-  int tm_yday; /* day in the year,  range 0 to 365 */
-  int tm_isdst;/* daylight saving time             */ //no=0, yes>0
-};
-#endif
+
 time_t mktime(struct tm *t);
 char*  ctime(const time_t *clock);
 int    gettimeofday(void *tp, void *tzp);

--- a/util/time.h
+++ b/util/time.h
@@ -1,9 +1,27 @@
 #ifndef TIME_H
 #define TIME_H
 
-typedef long size_t;
-typedef long time_t;
-typedef long clockid_t;
+#ifndef size_t
+#ifndef __SIZE_TYPE__
+#define __SIZE_TYPE__ long
+#endif
+typedef __SIZE_TYPE__ size_t;
+#endif
+
+#ifndef time_t
+#ifndef _TIME_T_
+#define _TIME_T_ long
+#endif
+typedef _TIME_T_ time_t;
+#endif
+
+#ifndef __clockid_t_defined
+#ifndef _CLOCKID_T_
+#define _CLOCKID_T_ long
+#endif
+typedef _CLOCKID_T_ clockid_t;
+#define __clockid_t_defined
+#endif
 
 #include "user_interface.h"
 
@@ -13,26 +31,15 @@ struct timeval
   long   tv_usec;
 };
 
+#ifndef __timespec_defined
+#define __timespec_defined
 struct timespec {
   time_t tv_sec;   /* Seconds */
   long   tv_nsec;  /* Nanoseconds */
 };
-
-//*******************************************************************
+#endif
 
 // time structure represents time A.D. (e.g. year: 2015)
-struct tm_t {
-  int tm_sec;  /* seconds,          range 0 to 59  */
-  int tm_min;  /* minutes,          range 0 to 59  */
-  int tm_hour; /* hours,            range 0 to 23  */
-  int tm_mday; /* day of the month, range 1 to 31  */
-  int tm_mon;  /* month,            range 0 to 11  */
-  int tm_year; /* number of years   since 1900     */
-  int tm_wday; /* day of the week,  range 0 to 6   */ //sunday = 0
-  int tm_yday; /* day in the year,  range 0 to 365 */
-  int tm_isdst;/* daylight saving time             */ //no=0, yes>0
-} tm_t;
-
 struct tm {
   int tm_sec;  /* seconds,          range 0 to 59  */
   int tm_min;  /* minutes,          range 0 to 59  */
@@ -43,16 +50,28 @@ struct tm {
   int tm_wday; /* day of the week,  range 0 to 6   */ //sunday = 0
   int tm_yday; /* day in the year,  range 0 to 365 */
   int tm_isdst;/* daylight saving time             */ //no=0, yes>0
-} tm;
-
-time_t mktime(struct tm_t *tm);
+};
+#ifdef MMM
+struct tm {
+  int tm_sec;  /* seconds,          range 0 to 59  */
+  int tm_min;  /* minutes,          range 0 to 59  */
+  int tm_hour; /* hours,            range 0 to 23  */
+  int tm_mday; /* day of the month, range 1 to 31  */
+  int tm_mon;  /* month,            range 0 to 11  */
+  int tm_year; /* number of years   since 1900     */
+  int tm_wday; /* day of the week,  range 0 to 6   */ //sunday = 0
+  int tm_yday; /* day in the year,  range 0 to 365 */
+  int tm_isdst;/* daylight saving time             */ //no=0, yes>0
+};
+#endif
+time_t mktime(struct tm *t);
 char*  ctime(const time_t *clock);
 int    gettimeofday(void *tp, void *tzp);
 int    clock_gettime(clockid_t clock_id, struct timespec *tp);
 
 void   configTime(unsigned long timezone, int daylight);
-time_t time(time_t * t);
-int    compareTime(struct tm_t *tm1, struct tm_t *tm2);
+time_t time(time_t *t);
+int    compareTime(struct tm *t1, struct tm *t2);
 
 #endif //TIME_H
 

--- a/util/user_config.h
+++ b/util/user_config.h
@@ -1,0 +1,4 @@
+//dummy file "user_config.h"
+//included from user_interface.h
+
+


### PR DESCRIPTION
I discovered these functions in sntp.h and found a way to use them.
The time is synced after one hour, which can be observed by Serial.setDebugOutput(true).
To start the service call configTime() when WiFi is turned on.
You need $(SDK_BASE) to compile
Just a few suggestions...
