### PR TITLE
axTLS fails to handshake with aws iot with SSL_ERROR_INVALID_HANDSHAKE. 

### DIFF
--- a/ssl/tls1_clnt.c
+++ b/ssl/tls1_clnt.c
@@ -350,7 +350,7 @@ static int process_server_hello(SSL *ssl)
     offset += 2; // ignore compression
     PARANOIA_CHECK(pkt_size, offset);
 
-    ssl->dc->bm_proc_index = offset+1; 
+    ssl->dc->bm_proc_index = offset;
     PARANOIA_CHECK(pkt_size, offset);
 
     // no extensions


### PR DESCRIPTION
It is a wrong offset. Problem is also confirmed [here](https://sourceforge.net/p/axtls/mailman/message/35293169/).
