### PR TITLE
Add support for verifying SHA-256 hash of Subject Public Key Info

### DIFF
--- a/ssl/crypto_misc.h
+++ b/ssl/crypto_misc.h
@@ -78,6 +78,7 @@ struct _x509_ctx
     RSA_CTX *rsa_ctx;
     bigint *digest;
     uint8_t *fingerprint;
+    uint8_t *spki_sha256;
     struct _x509_ctx *next;
 };
 

--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -417,6 +417,15 @@ EXP_FUNC int STDCALL ssl_verify_cert(const SSL *ssl);
 EXP_FUNC int STDCALL ssl_match_fingerprint(const SSL *ssl, const uint8_t* fp);
 
 /**
+ * @brief Check if SHA256 hash of Subject Public Key Info matches the one given.
+ *
+ * @param ssl [in] An SSL object reference.
+ * @param fp [in] SHA256 hash to match against
+ * @return SSL_OK if the certificate is verified.
+ */
+EXP_FUNC int STDCALL ssl_match_spki_sha256(const SSL *ssl, const uint8_t* hash);
+
+/**
  * @brief Retrieve an X.509 distinguished name component.
  * 
  * When a handshake is complete and a certificate has been exchanged, then the

--- a/ssl/tls1.c
+++ b/ssl/tls1.c
@@ -2210,6 +2210,25 @@ EXP_FUNC int STDCALL ssl_match_fingerprint(const SSL *ssl, const uint8_t* fp)
     return res;
 }
 
+EXP_FUNC int STDCALL ssl_match_spki_sha256(const SSL *ssl, const uint8_t* hash)
+{
+    if (ssl->x509_ctx == NULL || ssl->x509_ctx->spki_sha256 == NULL)
+        return 1;
+    int res = memcmp(ssl->x509_ctx->spki_sha256, hash, SHA256_SIZE);
+    if (res != 0) {
+        printf("cert SPKI SHA-256 hash: ");
+        for (int i = 0; i < SHA256_SIZE; ++i) {
+            printf("%02X ", ssl->x509_ctx->spki_sha256[i]);
+        }
+        printf("\r\ntest hash: ");
+        for (int i = 0; i < SHA256_SIZE; ++i) {
+            printf("%02X ", hash[i]);
+        }
+        printf("\r\n");
+    }
+    return res;
+}
+
 #endif /* CONFIG_SSL_CERT_VERIFICATION */
 
 /**


### PR DESCRIPTION
axtls provides a way to implement "SSH" style key verification by checking the SHA-1 hash of the (entire) certificate. Unfortunately this checksum changes every time the certificate is changed, e.g. because it's getting renewed (usually every year, for letsencrypt.org even every 3 months) or extended with new domains.

For HTTP public key pinning (RFC7469), the SHA-256 hash of the Subject
Public Key Info (which usually only changes when the public key
changes) is used rather than the SHA-1 hash of the entire certificate. This makes a lot of sense for use with axtls, too. This pull request introduces a new function ssl_match_spki_sha256() that allows an API consumer to verify the SHA-256 hash of the SPKI. The existing SHA-1 certificate hash verification support is left untouched so there should not be any compatibility concerns.
