### PR TITLE
Fix memleak in rsa.c

### DIFF
--- a/crypto/rsa.c
+++ b/crypto/rsa.c
@@ -150,14 +150,14 @@ int RSA_decrypt(const RSA_CTX *ctx, const uint8_t *in_data,
     uint8_t *block = NULL;
     int pad_count = 0;
 
-	do
-	{
+    do
+    {
     if (out_len < byte_size)        /* check output has enough size */
        break;
 
     block = (uint8_t *)malloc(byte_size);
-	if (!block)
-	   break;
+    if (!block)
+       break;
 
     memset(out_data, 0, out_len);   /* initialise */
 
@@ -203,12 +203,12 @@ int RSA_decrypt(const RSA_CTX *ctx, const uint8_t *in_data,
 
     /* get only the bit we want */
     memcpy(out_data, &block[i], size);
-	} while(false);
+    } while(false);
 
     if(block)
-	   free(block);
+       free(block);
 
-	return size;
+    return size;
 }
 
 /**

--- a/crypto/rsa.c
+++ b/crypto/rsa.c
@@ -145,13 +145,13 @@ int RSA_decrypt(const RSA_CTX *ctx, const uint8_t *in_data,
                             uint8_t *out_data, int out_len, int is_decryption)
 {
     const int byte_size = ctx->num_octets;
-    int i = 0, size;
+    int i = 0, size = -1;
     bigint *decrypted_bi, *dat_bi;
     uint8_t *block = (uint8_t *)malloc(byte_size);
     int pad_count = 0;
 
     if (out_len < byte_size)        /* check output has enough size */
-        return -1;
+       goto error;
 
     memset(out_data, 0, out_len);   /* initialise */
 
@@ -168,13 +168,13 @@ int RSA_decrypt(const RSA_CTX *ctx, const uint8_t *in_data,
     bi_export(ctx->bi_ctx, decrypted_bi, block, byte_size);
 
     if (block[i++] != 0)             /* leading 0? */
-        return -1;
+        goto error;
 
 #ifdef CONFIG_SSL_CERT_VERIFICATION
     if (is_decryption == 0) /* PKCS1.5 signing pads with "0xff"s */
     {
         if (block[i++] != 0x01)     /* BT correct? */
-            return -1;
+            goto error;
 
         while (block[i++] == 0xff && i < byte_size)
             pad_count++;
@@ -183,7 +183,7 @@ int RSA_decrypt(const RSA_CTX *ctx, const uint8_t *in_data,
 #endif
     {
         if (block[i++] != 0x02)     /* BT correct? */
-            return -1;
+            goto error;
 
         while (block[i++] && i < byte_size)
             pad_count++;
@@ -191,14 +191,16 @@ int RSA_decrypt(const RSA_CTX *ctx, const uint8_t *in_data,
 
     /* check separator byte 0x00 - and padding must be 8 or more bytes */
     if (i == byte_size || pad_count < 8) 
-        return -1;
+        goto error;
 
     size = byte_size - i;
 
     /* get only the bit we want */
     memcpy(out_data, &block[i], size);
-    free(block);
-    return size;
+
+error:
+	free(block);
+	return size;
 }
 
 /**


### PR DESCRIPTION
Because code is not using alloca anymore, malloc has to be freed always before returning from function.