### PR TITLE
Prevent rebood by feeding the watchdog

### DIFF
--- a/ssl/os_port.h
+++ b/ssl/os_port.h
@@ -96,7 +96,8 @@ extern "C" {
 #define be64toh(x) __bswap_constant_64(x)
 #endif
 
-void ax_wdt_feed();
+extern void system_soft_wdt_feed(void);
+#define ax_wdt_feed system_soft_wdt_feed
 
 #elif defined(WIN32)
 

--- a/ssl/tls1.c
+++ b/ssl/tls1.c
@@ -2091,6 +2091,8 @@ int process_certificate(SSL *ssl, X509_CTX **x509_ctx)
     int i = 0;
     offset += 2;
 
+    ax_wdt_feed();
+
     PARANOIA_CHECK(pkt_size, total_cert_len + offset);
 
     // record the start point for the second pass
@@ -2121,7 +2123,7 @@ int process_certificate(SSL *ssl, X509_CTX **x509_ctx)
         offset++;       /* skip empty char */
         cert_size = (buf[offset]<<8) + buf[offset+1];
         offset += 2;
-        
+        ax_wdt_feed();
         if (x509_new(&buf[offset], NULL, certs+num_certs))
         {
             ret = SSL_ERROR_BAD_CERTIFICATE;


### PR DESCRIPTION
Sometimes a reboot happens in one of these places. A wdt feed fixes it.