### PR TITLE
Prefixing max/min defines with axtls_ so they don't clash with other …

### DIFF
--- a/crypto/bigint.c
+++ b/crypto/bigint.c
@@ -282,7 +282,7 @@ bigint *bi_add(BI_CTX *ctx, bigint *bia, bigint *bib)
     check(bia);
     check(bib);
 
-    n = max(bia->size, bib->size);
+    n = axtls_max(bia->size, bib->size);
     more_comps(bia, n+1);
     more_comps(bib, n);
     pa = bia->comps;
@@ -876,7 +876,7 @@ static bigint *karatsuba(BI_CTX *ctx, bigint *bia, bigint *bib, int is_square)
     }
     else
     {
-        m = (max(bia->size, bib->size) + 1)/2;
+        m = (axtls_max(bia->size, bib->size) + 1)/2;
     }
 
     x0 = bi_clone(ctx, bia);
@@ -928,7 +928,7 @@ bigint *bi_multiply(BI_CTX *ctx, bigint *bia, bigint *bib)
     check(bib);
 
 #ifdef CONFIG_BIGINT_KARATSUBA
-    if (min(bia->size, bib->size) < MUL_KARATSUBA_THRESH)
+    if (axtls_min(bia->size, bib->size) < MUL_KARATSUBA_THRESH)
     {
         return regular_multiply(ctx, bia, bib, 0, 0);
     }
@@ -1068,7 +1068,7 @@ static void more_comps(bigint *bi, int n)
 {
     if (n > bi->max_comps)
     {
-        bi->max_comps = max(bi->max_comps * 2, n);
+        bi->max_comps = axtls_max(bi->max_comps * 2, n);
         bi->comps = (comp*)realloc(bi->comps, bi->max_comps * COMP_BYTE_SIZE);
     }
 

--- a/crypto/bigint_impl.h
+++ b/crypto/bigint_impl.h
@@ -121,10 +121,8 @@ typedef struct /**< A big integer "session" context. */
     uint8_t mod_offset;         /**< The mod offset we are using */
 } BI_CTX;
 
-#ifndef WIN32
-#define max(a,b) ((a)>(b)?(a):(b))  /**< Find the maximum of 2 numbers. */
-#define min(a,b) ((a)<(b)?(a):(b))  /**< Find the minimum of 2 numbers. */
-#endif
+#define axtls_max(a,b) ((a)>(b)?(a):(b))  /**< Find the maximum of 2 numbers. */
+#define axtls_min(a,b) ((a)<(b)?(a):(b))  /**< Find the minimum of 2 numbers. */
 
 #define PERMANENT           0x7FFF55AA  /**< A magic number for permanents. */
 


### PR DESCRIPTION
I'm currently trying to integrate the header files from here into arduino/esp8266, however the min and max function from bigint clash with the min and max function in the spiffs library.

Since we are just using the precompiled version, the change technically isn't needed (The substitution will have already been done, and no other code uses that definition), I thought it should be changed for consistency (in case it is decided to bring this tree in as a submodule). Having it modded will also allow me to test some TLS stuff under CI (I'll need to compile axtls for x86 to run on travis)

Since this is an old version of axtls, I thought it easier to rename here.