### PR TITLE
Optimize add_hmac_digest to prevent extra allocations

### DIFF
--- a/crypto/crypto.h
+++ b/crypto/crypto.h
@@ -204,6 +204,16 @@ void hmac_sha256(const uint8_t *msg, int length, const uint8_t *key,
         int key_len, uint8_t *digest);
 
 /**************************************************************************
+ * HMAC functions operating on vectors 
+ **************************************************************************/
+void hmac_md5_v(const uint8_t **msg, int* length, int count, const uint8_t *key, 
+        int key_len, uint8_t *digest);
+void hmac_sha1_v(const uint8_t **msg, int* length, int count, const uint8_t *key, 
+        int key_len, uint8_t *digest);
+void hmac_sha256_v(const uint8_t **msg, int* length, int count, const uint8_t *key, 
+        int key_len, uint8_t *digest);
+
+/**************************************************************************
  * RSA declarations 
  **************************************************************************/
 

--- a/crypto/hmac.c
+++ b/crypto/hmac.c
@@ -45,6 +45,12 @@
 void hmac_md5(const uint8_t *msg, int length, const uint8_t *key, 
         int key_len, uint8_t *digest)
 {
+    hmac_md5_v(&msg, &length, 1, key, key_len, digest);
+}
+
+void hmac_md5_v(const uint8_t **msg, int* length, int count, const uint8_t *key, 
+        int key_len, uint8_t *digest)
+{
     MD5_CTX context;
     uint8_t k_ipad[64];
     uint8_t k_opad[64];
@@ -63,7 +69,10 @@ void hmac_md5(const uint8_t *msg, int length, const uint8_t *key,
 
     MD5_Init(&context);
     MD5_Update(&context, k_ipad, 64);
-    MD5_Update(&context, msg, length);
+    for (i = 0; i < count; ++i) 
+    {
+        MD5_Update(&context, msg[i], length[i]);
+    }
     MD5_Final(digest, &context);
     MD5_Init(&context);
     MD5_Update(&context, k_opad, 64);
@@ -76,6 +85,12 @@ void hmac_md5(const uint8_t *msg, int length, const uint8_t *key,
  * NOTE: does not handle keys larger than the block size.
  */
 void hmac_sha1(const uint8_t *msg, int length, const uint8_t *key, 
+        int key_len, uint8_t *digest)
+{
+    hmac_sha1_v(&msg, &length, 1, key, key_len, digest);
+}
+
+void hmac_sha1_v(const uint8_t **msg, int *length, int count, const uint8_t *key, 
         int key_len, uint8_t *digest)
 {
     SHA1_CTX context;
@@ -96,7 +111,10 @@ void hmac_sha1(const uint8_t *msg, int length, const uint8_t *key,
 
     SHA1_Init(&context);
     SHA1_Update(&context, k_ipad, 64);
-    SHA1_Update(&context, msg, length);
+    for (i = 0; i < count; ++i) 
+    {
+        SHA1_Update(&context, msg[i], length[i]);
+    }
     SHA1_Final(digest, &context);
     SHA1_Init(&context);
     SHA1_Update(&context, k_opad, 64);
@@ -109,6 +127,12 @@ void hmac_sha1(const uint8_t *msg, int length, const uint8_t *key,
  * NOTE: does not handle keys larger than the block size.
  */
 void hmac_sha256(const uint8_t *msg, int length, const uint8_t *key, 
+        int key_len, uint8_t *digest)
+{
+    hmac_sha256_v(&msg, &length, 1, key, key_len, digest);
+}
+
+void hmac_sha256_v(const uint8_t **msg, int *length, int count, const uint8_t *key, 
         int key_len, uint8_t *digest)
 {
     SHA256_CTX context;
@@ -129,7 +153,10 @@ void hmac_sha256(const uint8_t *msg, int length, const uint8_t *key,
 
     SHA256_Init(&context);
     SHA256_Update(&context, k_ipad, 64);
-    SHA256_Update(&context, msg, length);
+    for (i = 0; i < count; ++i) 
+    {
+        SHA256_Update(&context, msg[i], length[i]);
+    }
     SHA256_Final(digest, &context);
     SHA256_Init(&context);
     SHA256_Update(&context, k_opad, 64);

--- a/ssl/crypto_misc.h
+++ b/ssl/crypto_misc.h
@@ -195,6 +195,9 @@ extern const char * const unsupported_str;
 typedef void (*crypt_func)(void *, const uint8_t *, uint8_t *, int);
 typedef void (*hmac_func)(const uint8_t *msg, int length, const uint8_t *key, 
         int key_len, uint8_t *digest);
+typedef void (*hmac_func_v)(const uint8_t **msg, int *length, int count, const uint8_t *key, 
+        int key_len, uint8_t *digest);
+
 
 int get_file(const char *filename, uint8_t **buf);
 

--- a/ssl/tls1.h
+++ b/ssl/tls1.h
@@ -132,7 +132,7 @@ typedef struct
     uint8_t padding_size;
     uint8_t digest_size;
     uint8_t key_block_size;
-    hmac_func hmac;
+    hmac_func_v hmac_v;
     crypt_func encrypt;
     crypt_func decrypt;
 } cipher_info_t;


### PR DESCRIPTION
`add_hmac_digest` used to allocate a temporary buffer with size which could be equal to the maximum fragment size. This was only necessary because `hmac` functions accepted a contiguous buffer as an input. This change adds variants of `hmac` functions which accept a vector of buffers as input (aka "gather" input), and uses these new functions to calculate digest in-place, without extra memory allocation.