### PR TITLE
Save ~3KB of RAM by moving constant strings out of RODATA

### DIFF
--- a/ssl/crypto_misc.h
+++ b/ssl/crypto_misc.h
@@ -127,7 +127,7 @@ int x509_verify(const CA_CERT_CTX *ca_cert_ctx, const X509_CTX *cert,
 #endif
 #ifdef CONFIG_SSL_FULL_MODE
 void x509_print(const X509_CTX *cert, CA_CERT_CTX *ca_cert_ctx);
-const char * x509_display_error(int error);
+const char * x509_display_error(int error, char *buff);
 #endif
 
 /**************************************************************************

--- a/ssl/tls1.c
+++ b/ssl/tls1.c
@@ -2287,58 +2287,57 @@ void DISPLAY_STATE(SSL *ssl, int is_send, uint8_t state, int not_ok)
     if (!IS_SET_SSL_FLAG(SSL_DISPLAY_STATES))
         return;
 
-    printf(not_ok ? "Error - invalid State:\t" : "State:\t");
-    printf(is_send ? "sending " : "receiving ");
+    if (not_ok) printf("Error - invalid State:\t");
+    else printf("State:\t");
+    if (is_send) printf("sending ");
+    else printf("receiving ");
 
     switch (state)
     {
         case HS_HELLO_REQUEST:
-            str = "Hello Request (0)";
+            printf("Hello Request (0)\n");
             break;
 
         case HS_CLIENT_HELLO:
-            str = "Client Hello (1)";
+            printf("Client Hello (1)\n");
             break;
 
         case HS_SERVER_HELLO:
-            str = "Server Hello (2)";
+            printf("Server Hello (2)\n");
             break;
 
         case HS_CERTIFICATE:
-            str = "Certificate (11)";
+            printf("Certificate (11)\n");
             break;
 
         case HS_SERVER_KEY_XCHG:
-            str = "Certificate Request (12)";
+            printf("Certificate Request (12)\n");
             break;
 
         case HS_CERT_REQ:
-            str = "Certificate Request (13)";
+            printf("Certificate Request (13)\n");
             break;
 
         case HS_SERVER_HELLO_DONE:
-            str = "Server Hello Done (14)";
+            printf("Server Hello Done (14)\n");
             break;
 
         case HS_CERT_VERIFY:
-            str = "Certificate Verify (15)";
+            printf("Certificate Verify (15)\n");
             break;
 
         case HS_CLIENT_KEY_XCHG:
-            str = "Client Key Exchange (16)";
+            printf("Client Key Exchange (16)\n");
             break;
 
         case HS_FINISHED:
-            str = "Finished (16)";
+            printf("Finished (16)\n");
             break;
 
         default:
-            str = "Error (Unknown)";
-            
+            printf("Error (Unknown)\n");
             break;
     }
-
-    printf("%s\n", str);
 }
 
 /**
@@ -2383,7 +2382,8 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code)
     /* X509 error? */
     if (error_code < SSL_X509_OFFSET)
     {
-        printf("%s\n", x509_display_error(error_code - SSL_X509_OFFSET));
+        char buff[64];
+        printf("%s\n", x509_display_error(error_code - SSL_X509_OFFSET, buff));
         return;
     }
 

--- a/ssl/x509.c
+++ b/ssl/x509.c
@@ -225,8 +225,9 @@ end_cert:
     if (ret)
     {
 #ifdef CONFIG_SSL_FULL_MODE
+        char buff[64];
         printf("Error: Invalid X509 ASN.1 file (%s)\n",
-                        x509_display_error(ret));
+                        x509_display_error(ret, buff));
 #endif
         x509_free(x509_ctx);
         *ctx = NULL;
@@ -821,9 +822,10 @@ void x509_print(const X509_CTX *cert, CA_CERT_CTX *ca_cert_ctx)
     if (ca_cert_ctx)
     {
         int pathLenConstraint = 0;
+        char buff[64];
         printf("Verify:\t\t\t\t%s\n",
                 x509_display_error(x509_verify(ca_cert_ctx, cert,
-                        &pathLenConstraint)));
+                        &pathLenConstraint), buff));
     }
 
 #if 0
@@ -840,45 +842,57 @@ void x509_print(const X509_CTX *cert, CA_CERT_CTX *ca_cert_ctx)
     TTY_FLUSH();
 }
 
-const char * x509_display_error(int error)
+const char * x509_display_error(int error, char *buff)
 {
     switch (error)
     {
         case X509_OK:
-            return "Certificate verify successful";
+            strcpy_P(buff, "Certificate verify successful");
+            return buff;
 
         case X509_NOT_OK:
-            return "X509 not ok";
+            strcpy_P(buff, "X509 not ok");
+            return buff;
 
         case X509_VFY_ERROR_NO_TRUSTED_CERT:
-            return "No trusted cert is available";
+            strcpy_P(buff, "No trusted cert is available");
+            return buff;
 
         case X509_VFY_ERROR_BAD_SIGNATURE:
-            return "Bad signature";
+            strcpy_P(buff, "Bad signature");
+            return buff;
 
         case X509_VFY_ERROR_NOT_YET_VALID:
-            return "Cert is not yet valid";
+            strcpy_P(buff, "Cert is not yet valid");
+            return buff;
 
         case X509_VFY_ERROR_EXPIRED:
-            return "Cert has expired";
+            strcpy_P(buff, "Cert has expired");
+            return buff;
 
         case X509_VFY_ERROR_SELF_SIGNED:
-            return "Cert is self-signed";
+            strcpy_P(buff, "Cert is self-signed");
+            return buff;
 
         case X509_VFY_ERROR_INVALID_CHAIN:
-            return "Chain is invalid (check order of certs)";
+            strcpy_P(buff, "Chain is invalid (check order of certs)");
+            return buff;
 
         case X509_VFY_ERROR_UNSUPPORTED_DIGEST:
-            return "Unsupported digest";
+            strcpy_P(buff, "Unsupported digest");
+            return buff;
 
         case X509_INVALID_PRIV_KEY:
-            return "Invalid private key";
+            strcpy_P(buff, "Invalid private key");
+            return buff;
 
         case X509_VFY_ERROR_BASIC_CONSTRAINT:
-            return "Basic constraint invalid";
+            strcpy_P(buff, "Basic constraint invalid");
+            return buff;
 
         default:
-            return "Unknown";
+            strcpy_P(buff, "Unknown");
+            return buff;
     }
 }
 #endif      /* CONFIG_SSL_FULL_MODE */


### PR DESCRIPTION
This complements the work you've been doing on moving the constant arrays in the encryption routines to PMEM.

Constant text strings actually take up SRAM space on the ESP8266 because the .RODATA segment must be copied to the top of RAM at startup since FLASH isn't byte-accessible but all string(char*) functions (like ets_printf, Serial.*, etc.) need this.  There are a *lot* of string literals in the axtls code for certificate debugging, and that eats up nearly 10% of the free RAM in any project w/SSL.

This patch moves the constant format strings in axtls' printf completely into FLASH and add a wrapper to copy it into a local stack-allocated space when needed, freeing up about 3100 bytes of RAM for use.  This doesn't make FLASH usage any higher, either, since those strings were already being stored there (but never used after the power-on startup code).

Minor edits required in some of the output/debug/tracing functions, but no logic changed.

Constant strings do NOT show up in the symbol table, so they aren't easily visible by many tools like READELF.  One easy way to check what string literals are eating up RAM in RODATA is to use the command:
`objdump`  -s -j .rodata /tmp/arduino_build_89991/*.elf
where the number will vary depending on the Arduino PID, etc.
