### PR TITLE
Fix memory leak of ssl_ext_host_name, losing memory every SSL disconnect

### DIFF
--- a/ssl/tls1.c
+++ b/ssl/tls1.c
@@ -159,6 +159,8 @@ EXP_FUNC void STDCALL ssl_ext_free(SSL_EXTENSIONS *ssl_ext)
         return;
     }
 
+    free(ssl_ext->host_name); // strdup()'d in ssl_ext_set_host_name()
+
     free(ssl_ext);
 }
 


### PR DESCRIPTION
@Jeroen88 found a memory leak in axtls where the new ext_host_name pointer was leaking on every SSL reconnection, eventually eating up all RAM and crashing the chip (see esp8266/Arduino#3428 ).

This 1-line patch just frees the allocated hostname in during the ssl_ext_free call, eliminating the leakage.
