### PR TITLE
Remove compile warnings, move add'l consts to PMEM

### DIFF
--- a/crypto/crypto_misc.c
+++ b/crypto/crypto_misc.c
@@ -61,8 +61,6 @@ static HCRYPTPROV gCryptProv;
 static uint8_t entropy_pool[ENTROPY_POOL_SIZE];
 #endif
 
-const char * const unsupported_str = "Error: Feature not supported\n";
-
 #ifndef CONFIG_SSL_SKELETON_MODE
 /**
  * Retrieve a file and put it into memory

--- a/crypto/rsa.c
+++ b/crypto/rsa.c
@@ -238,9 +238,9 @@ void RSA_print(const RSA_CTX *rsa_ctx)
 
     printf("-----------------   RSA DEBUG   ----------------\n");
     printf("Size:\t%d\n", rsa_ctx->num_octets);
-    bi_print("Modulus", rsa_ctx->m);
-    bi_print("Public Key", rsa_ctx->e);
-    bi_print("Private Key", rsa_ctx->d);
+    printf("Modulus"); bi_print("", rsa_ctx->m);
+    printf("Public Key"); bi_print("", rsa_ctx->e);
+    printf("Private Key"); bi_print("", rsa_ctx->d);
 }
 #endif
 

--- a/ssl/asn1.c
+++ b/ssl/asn1.c
@@ -229,7 +229,6 @@ int asn1_get_bit_string_as_int(const uint8_t *buf, int *offset, uint32_t *val)
 {
     int res = X509_OK;
     int len, i;
-    int ignore_bits;
 
     if ((len = asn1_next_obj(buf, offset, ASN1_BIT_STRING)) < 0 || len > 5)
     {
@@ -238,7 +237,6 @@ int asn1_get_bit_string_as_int(const uint8_t *buf, int *offset, uint32_t *val)
     }
 
     /* number of bits left unused in the final byte of content */
-    ignore_bits = buf[(*offset)++];
     len--;
     *val = 0;
 
@@ -250,11 +248,6 @@ int asn1_get_bit_string_as_int(const uint8_t *buf, int *offset, uint32_t *val)
     }
 
     *offset += len;
-
-    /*for (i = 0; i < ignore_bits; i++)
-    {
-        *val >>= 1;
-    }*/
 
 end_bit_string_as_int:
     return res;

--- a/ssl/crypto_misc.h
+++ b/ssl/crypto_misc.h
@@ -190,7 +190,7 @@ int asn1_signature_type(const uint8_t *cert,
  **************************************************************************/
 #define SALT_SIZE               8
 
-extern const char * const unsupported_str;
+#define unsupported_str "Error: Feature not supported\n"
 
 typedef void (*crypt_func)(void *, const uint8_t *, uint8_t *, int);
 typedef void (*hmac_func)(const uint8_t *msg, int length, const uint8_t *key, 

--- a/ssl/loader.c
+++ b/ssl/loader.c
@@ -83,7 +83,7 @@ EXP_FUNC int STDCALL ssl_obj_load(SSL_CTX *ssl_ctx, int obj_type,
         ret = ssl_obj_PEM_load(ssl_ctx, obj_type, ssl_obj, password);
 #else
 #ifdef CONFIG_SSL_FULL_MODE
-        printf("%s", unsupported_str);
+        printf(unsupported_str);
 #endif
         ret = SSL_ERROR_NOT_SUPPORTED;
 #endif
@@ -96,7 +96,7 @@ error:
     return ret;
 #else
 #ifdef CONFIG_SSL_FULL_MODE
-    printf("%s", unsupported_str);
+    printf(unsupported_str);
 #endif
     return SSL_ERROR_NOT_SUPPORTED;
 #endif /* CONFIG_SSL_SKELETON_MODE */
@@ -155,7 +155,7 @@ static int do_obj(SSL_CTX *ssl_ctx, int obj_type,
 #endif
         default:
 #ifdef CONFIG_SSL_FULL_MODE
-            printf("%s", unsupported_str);
+            printf(unsupported_str);
 #endif
             ret = SSL_ERROR_NOT_SUPPORTED;
             break;

--- a/ssl/os_port.h
+++ b/ssl/os_port.h
@@ -137,8 +137,24 @@ static inline void* memcpy_P(void* dest, PGM_VOID_P src, size_t count) {
 
     return dest;
 }
+static inline int strlen_P(const char *str) {
+    int cnt = 0;
+    while (pgm_read_byte(str++)) cnt++;
+    return cnt;
+}
 #define printf(fmt, ...) do { static const char fstr[] PROGMEM = fmt; char rstr[sizeof(fmt)]; memcpy_P(rstr, fstr, sizeof(rstr)); ets_printf(rstr, ##__VA_ARGS__); } while (0)
 #define strcpy_P(dst, src) do { static const char fstr[] PROGMEM = src; memcpy_P(dst, fstr, sizeof(src)); } while (0)
+
+// Copied from ets_sys.h to avoid compile warnings
+extern int ets_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+extern int ets_putc(int);
+
+// The network interface in WiFiClientSecure
+extern int ax_port_read(int fd, uint8_t* buffer, size_t count);
+extern int ax_port_write(int fd, uint8_t* buffer, size_t count);
+
+// TODO: Why is this not being imported from <string.h>?
+extern char *strdup(const char *orig);
 
 #elif defined(WIN32)
 

--- a/ssl/tls1.c
+++ b/ssl/tls1.c
@@ -978,7 +978,7 @@ void generate_master_secret(SSL *ssl, const uint8_t *premaster_secret)
 {
     uint8_t buf[77]; 
 //print_blob("premaster secret", premaster_secret, 48);
-    strcpy((char *)buf, "master secret");
+    strcpy_P((char*)buf, "master secret");
     memcpy(&buf[13], ssl->dc->client_random, SSL_RANDOM_SIZE);
     memcpy(&buf[45], ssl->dc->server_random, SSL_RANDOM_SIZE);
     prf(ssl, premaster_secret, SSL_SECRET_SIZE, buf, 77, ssl->dc->master_secret,
@@ -998,7 +998,7 @@ static void generate_key_block(SSL *ssl,
         uint8_t *master_secret, uint8_t *key_block, int key_block_size)
 {
     uint8_t buf[77];
-    strcpy((char *)buf, "key expansion");
+    strcpy_P((char *)buf, "key expansion");
     memcpy(&buf[13], server_random, SSL_RANDOM_SIZE);
     memcpy(&buf[45], client_random, SSL_RANDOM_SIZE);
     prf(ssl, master_secret, SSL_SECRET_SIZE, buf, 77, 
@@ -1125,7 +1125,7 @@ static int send_raw_packet(SSL *ssl, uint8_t protocol)
     rec_buf[3] = ssl->bm_index >> 8;
     rec_buf[4] = ssl->bm_index & 0xff;
 
-    DISPLAY_BYTES(ssl, "sending %d bytes", ssl->bm_all_data, 
+    DISPLAY_BYTES(ssl, PSTR("sending %d bytes"), ssl->bm_all_data, 
                              pkt_size, pkt_size);
 
     while (sent < pkt_size)
@@ -1234,7 +1234,7 @@ int send_packet(SSL *ssl, uint8_t protocol, const uint8_t *in, int length)
             msg_length += pad_bytes;
         }
 
-        DISPLAY_BYTES(ssl, "unencrypted write", ssl->bm_data, msg_length);
+        DISPLAY_BYTES(ssl, PSTR("unencrypted write"), ssl->bm_data, msg_length);
         increment_write_sequence(ssl);
 
         /* add the explicit IV for TLS1.1 */
@@ -1392,7 +1392,7 @@ int basic_read(SSL *ssl, uint8_t **in_data)
         goto error;
     }
 
-    DISPLAY_BYTES(ssl, "received %d bytes", 
+    DISPLAY_BYTES(ssl, PSTR("received %d bytes"), 
             &ssl->bm_data[ssl->bm_read_index], read_len, read_len);
 
     ssl->got_bytes += read_len;
@@ -1469,7 +1469,7 @@ int basic_read(SSL *ssl, uint8_t **in_data)
             goto error;
         }
 
-        DISPLAY_BYTES(ssl, "decrypted", buf, read_len);
+        DISPLAY_BYTES(ssl, PSTR("decrypted"), buf, read_len);
         increment_read_sequence(ssl);
     }
 
@@ -2290,8 +2290,6 @@ EXP_FUNC int STDCALL ssl_match_spki_sha256(const SSL *ssl, const uint8_t* hash)
  */
 void DISPLAY_STATE(SSL *ssl, int is_send, uint8_t state, int not_ok)
 {
-    const char *str;
-
     if (!IS_SET_SSL_FLAG(SSL_DISPLAY_STATES))
         return;
 
@@ -2372,7 +2370,12 @@ void DISPLAY_BYTES(SSL *ssl, const char *format,
         return;
 
     va_start(ap, size);
-    print_blob(format, data, size, va_arg(ap, char *));
+    char fmt_ram[64];
+    int len = strlen_P(format) + 1;
+    if (len > sizeof(fmt_ram)) len = sizeof(fmt_ram);
+    memcpy_P(fmt_ram, format, len);
+    fmt_ram[sizeof(fmt_ram)-1] = 0;
+    print_blob(fmt_ram, data, size, va_arg(ap, char *));
     va_end(ap);
     TTY_FLUSH();
 }
@@ -2580,7 +2583,7 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code) {}
 EXP_FUNC SSL * STDCALL ssl_client_new(SSL_CTX *ssl_ctx, int client_fd, const
         uint8_t *session_id, uint8_t sess_id_size)
 {
-    printf("%s", unsupported_str);
+    printf(unsupported_str);
     return NULL;
 }
 #endif
@@ -2588,20 +2591,20 @@ EXP_FUNC SSL * STDCALL ssl_client_new(SSL_CTX *ssl_ctx, int client_fd, const
 #if !defined(CONFIG_SSL_CERT_VERIFICATION)
 EXP_FUNC int STDCALL ssl_verify_cert(const SSL *ssl)
 {
-    printf("%s", unsupported_str);
+    printf(unsupported_str);
     return -1;
 }
 
 
 EXP_FUNC const char * STDCALL ssl_get_cert_dn(const SSL *ssl, int component)
 {
-    printf("%s", unsupported_str);
+    printf(unsupported_str);
     return NULL;
 }
 
 EXP_FUNC const char * STDCALL ssl_get_cert_subject_alt_dnsname(const SSL *ssl, int index)
 {
-    printf("%s", unsupported_str);
+    printf(unsupported_str);
     return NULL;
 }
 

--- a/ssl/tls1.h
+++ b/ssl/tls1.h
@@ -175,7 +175,7 @@ typedef struct
 
 typedef struct 
 {
-    const char *host_name; /* Needed for the SNI support */
+    char *host_name; /* Needed for the SNI support */
     /* Needed for the Max Fragment Size Extension. 
        Allowed values: 2^9, 2^10 .. 2^14 */
     uint16_t max_fragment_size; 

--- a/ssl/x509.c
+++ b/ssl/x509.c
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <sys/time.h>
 #include "os_port.h"
 #include "crypto_misc.h"
 
@@ -636,11 +637,15 @@ end_verify:
 /**
  * Used for diagnostics.
  */
-static const char *not_part_of_cert = "<Not Part Of Certificate>";
 void x509_print(const X509_CTX *cert, CA_CERT_CTX *ca_cert_ctx) 
 {
     if (cert == NULL)
         return;
+
+    char not_part_of_cert[30];
+    strcpy_P(not_part_of_cert, "<Not Part Of Certificate>");
+    char critical[16];
+    strcpy_P(critical, "critical, ");
 
     printf("=== CERTIFICATE ISSUED TO ===\n");
     printf("Common Name (CN):\t\t");
@@ -679,7 +684,7 @@ void x509_print(const X509_CTX *cert, CA_CERT_CTX *ca_cert_ctx)
     {
         printf("Basic Constraints:\t\t%sCA:%s, pathlen:%d\n",
                 cert->basic_constraint_is_critical ? 
-                    "critical, " : "",
+                    critical : "",
                 cert->basic_constraint_cA? "TRUE" : "FALSE",
                 cert->basic_constraint_pathLenConstraint);
     }
@@ -687,7 +692,7 @@ void x509_print(const X509_CTX *cert, CA_CERT_CTX *ca_cert_ctx)
     if (cert->key_usage_present)
     {
         printf("Key Usage:\t\t\t%s", cert->key_usage_is_critical ? 
-                    "critical, " : "");
+                    critical : "");
         bool has_started = false;
 
         if (IS_SET_KEY_USAGE_FLAG(cert, KEY_USAGE_DIGITAL_SIGNATURE))
@@ -774,7 +779,7 @@ void x509_print(const X509_CTX *cert, CA_CERT_CTX *ca_cert_ctx)
     if (cert->subject_alt_name_present)
     {
         printf("Subject Alt Name:\t\t%s", cert->subject_alt_name_is_critical 
-                ?  "critical, " : "");
+                ?  critical : "");
         if (cert->subject_alt_dnsnames)
         {
             int i = 0;

--- a/util/time.h
+++ b/util/time.h
@@ -1,11 +1,8 @@
 #ifndef TIME_H
 #define TIME_H
 
-struct timeval
-{
-  time_t tv_sec;
-  long   tv_usec;
-};
+#include <time.h>
+#include <sys/time.h>
 
 
 #endif //TIME_H


### PR DESCRIPTION
There were some simple-to-fix compile warnings relating to missing
imports and datatypes.  Add proper includes (and replace the hacked
util/time.h definition of timeval with the real one in our SDK).

Also migrate multiple constant strings with minimal code changes, freeing
around 210 additional bytes of heap.