### PR TITLE
Fix handling of padded TLS fragments in handshake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,12 @@ script:
   - export PATH="$HOME/arduino_ide:$PATH"
   - which arduino
   - cd $ESP8266_ARDUINO_DIR
+  # 2.4.2 common.sh errors out if there is no valid build_type set, so ignore error
+  - sed -i 's/exit 1//' tests/common.sh
   - source tests/common.sh
   - arduino --board esp8266com:esp8266:generic --save-prefs
   - arduino --get-pref sketchbook.path
-  - build_sketches $HOME/arduino_ide $ESP8266_ARDUINO_DIR/libraries/ESP8266WiFi/examples/HTTPSRequest
+  - build_sketches $HOME/arduino_ide $ESP8266_ARDUINO_DIR/libraries/ESP8266WiFi/examples/HTTPSRequest "-l $ESP8266_ARDUINO_DIR/libraries" 1 0
   # Feel free to add more test cases (for other environments) here
 
 notifications:

--- a/ssl/tls1_clnt.c
+++ b/ssl/tls1_clnt.c
@@ -392,8 +392,9 @@ static int process_server_hello(SSL *ssl)
         }
     }
 
-    ssl->dc->bm_proc_index = offset;
-    PARANOIA_CHECK(pkt_size, offset);
+    ssl->dc->bm_proc_index = pkt_size;
+    /* This check not always valid w/padding: */
+    /* PARANOIA_CHECK(pkt_size, offset); */
 
 error:
     return ret;


### PR DESCRIPTION
When multiple handshake messages are sent in a single fragment, there
may be some padding (i.e. pkt_size will be larger than the amount of bytes
processed).  When this happens, the old code would only advance the working
pointer to the end of processed data, which would not be the start of the
next packet per the sent pkt_size, causing handshake failure.

Now simply advance the working pointer to the next packet irrespective
of how many bytes in the current one were processed in the server_hello
message.