### PR TITLE
FIX: asn1: parsing of bit string for key usage

### DIFF
--- a/ssl/crypto_misc.h
+++ b/ssl/crypto_misc.h
@@ -74,15 +74,15 @@ extern "C" {
  */
 #define IS_SET_KEY_USAGE_FLAG(A, B)          (A->key_usage & B)
 
-#define KEY_USAGE_DIGITAL_SIGNATURE         0x0080
-#define KEY_USAGE_NON_REPUDIATION           0x0040
-#define KEY_USAGE_KEY_ENCIPHERMENT          0x0020
-#define KEY_USAGE_DATA_ENCIPHERMENT         0x0010
-#define KEY_USAGE_KEY_AGREEMENT             0x0008
-#define KEY_USAGE_KEY_CERT_SIGN             0x0004
-#define KEY_USAGE_CRL_SIGN                  0x0002
-#define KEY_USAGE_ENCIPHER_ONLY             0x0001
-#define KEY_USAGE_DECIPHER_ONLY             0x8000
+#define KEY_USAGE_DIGITAL_SIGNATURE         0x0001
+#define KEY_USAGE_NON_REPUDIATION           0x0002
+#define KEY_USAGE_KEY_ENCIPHERMENT          0x0004
+#define KEY_USAGE_DATA_ENCIPHERMENT         0x0008
+#define KEY_USAGE_KEY_AGREEMENT             0x0010
+#define KEY_USAGE_KEY_CERT_SIGN             0x0020
+#define KEY_USAGE_CRL_SIGN                  0x0040
+#define KEY_USAGE_ENCIPHER_ONLY             0x0080
+#define KEY_USAGE_DECIPHER_ONLY             0x0100
 
 struct _x509_ctx
 {


### PR DESCRIPTION
To see what does not work load a certificate with this library and dump it. Then do this with `openssl x509 -in cert.der -inform der -noout -text` and compare the key usage fields!

The parsing algorithm for bit strings was not correct:
1. The offset wasn't correct at the end of the function (one too low)
2. Bit strings are encoded in big endian byte order, not little endian.
3. The most significant bit of the bit string as number (taking into account of the bit string length) has to be the least significant bit of the key usage value (see https://security.stackexchange.com/a/10396)

No. 1 didn't produce following errors because the rest of the outer ASN.1 sequence is skipped after calling this function (asn1_get_bit_string_as_int).