### PR TITLE
Make certificate validation work again

### DIFF
--- a/ssl/asn1.c
+++ b/ssl/asn1.c
@@ -237,6 +237,7 @@ int asn1_get_bit_string_as_int(const uint8_t *buf, int *offset, uint32_t *val)
     }
 
     /* number of bits left unused in the final byte of content */
+    (*offset)++;
     len--;
     *val = 0;
 


### PR DESCRIPTION
ASN1.c lost an increment, leading to certificates being parsed with
the wrong value read as the key usages (leading to failures in some cases).
Re-apply from the original axtls sources.