### PR TITLE
Modify to work with new toolchain, fix x509 decode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   # Copy the library into Arduino core
   - cp bin/libaxtls.a $ESP8266_ARDUINO_DIR/tools/sdk/lib/libaxtls.a
   # Try building examples in ESP8266WiFi library from the ESP8266 Arduino core
-  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
+  # - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
   - sleep 3
   - export DISPLAY=:1.0
   - export PATH="$HOME/arduino_ide:$PATH"
@@ -36,7 +36,8 @@ script:
   - source tests/common.sh
   - arduino --board esp8266com:esp8266:generic --save-prefs
   - arduino --get-pref sketchbook.path
-  - build_sketches $HOME/arduino_ide $ESP8266_ARDUINO_DIR/libraries/ESP8266WiFi/examples/HTTPSRequest "-l $ESP8266_ARDUINO_DIR/libraries" 1 0
+  - mkdir /tmp/cache
+  - cache_dir=/tmp/cache build_sketches $HOME/arduino_ide $ESP8266_ARDUINO_DIR/libraries/ESP8266WiFi/examples/HTTPSRequest "-l $ESP8266_ARDUINO_DIR/libraries" 1 0 lm2f
   # Feel free to add more test cases (for other environments) here
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -40,24 +40,13 @@ LDFLAGS  += 	-L$(XTENSA_LIBS)/lib \
 		-L$(XTENSA_LIBS)/arch/lib \
 
 
-CFLAGS+=-std=c99 -DESP8266
+CFLAGS+=-std=gnu99 -DESP8266 -DWITH_PGM_READ_HELPER
 
 CFLAGS += -Wall -Os -g -O2 -Wpointer-arith -Wl,-EL -nostdlib -mlongcalls -mno-text-section-literals  -D__ets__ -DICACHE_FLASH
 
 CFLAGS += -ffunction-sections -fdata-sections
 
 CFLAGS += -fdebug-prefix-map=$(PWD)= -fdebug-prefix-map=$(TOOLCHAIN_DIR)=xtensa-lx106-elf -gno-record-gcc-switches
-
-MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
-ifneq ($(MFORCE32),)
-    # If the compiler supports the -mforce-l32 flag, the compiler will generate correct code for loading
-    # 16- and 8-bit constants from program memory. So in the code we can directly access the arrays
-    # placed into program memory.
-    CFLAGS +=  -mforce-l32
-else
-	# Otherwise we need to use a helper function to load 16- and 8-bit constants from program memory.
-    CFLAGS += -DWITH_PGM_READ_HELPER
-endif
 
 BIN_DIR := bin
 AXTLS_AR := $(BIN_DIR)/libaxtls.a

--- a/crypto/sha256.c
+++ b/crypto/sha256.c
@@ -251,7 +251,7 @@ void SHA256_Final(uint8_t *digest, SHA256_CTX *ctx)
     uint8_t msglen[8];
 #ifdef WITH_PGM_READ_HELPER
     uint8_t sha256_padding_ram[64];
-    memcpy(sha256_padding_ram, sha256_padding, 64);
+    memcpy_P(sha256_padding_ram, sha256_padding, 64);
 #endif
 
     high = (ctx->total[0] >> 29)

--- a/ssl/os_port.h
+++ b/ssl/os_port.h
@@ -102,6 +102,22 @@ void ax_wdt_feed();
 #define ax_array_read_u8(x, y) x[y]
 #else
 
+#if (HAS_PROGMEM_FCNS==0)
+static inline uint8_t pgm_read_byte(const void* addr) {
+  register uint32_t res;
+  __asm__("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */
+      "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */
+      "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */
+      "slli     %0, %0, 3\n"        /* Multiply offset by 8, yielding an offset in bits */
+      "ssr      %0\n"               /* Prepare to shift by offset (in bits) */
+      "srl      %0, %1\n"           /* Shift right; now the requested byte is the first one */
+      :"=r"(res), "=r"(addr)
+      :"1"(addr)
+      :);
+  return (uint8_t) res;     /* This masks the lower byte from the returned word */
+}
+#endif
+
 #define ax_array_read_u8(x, y) pgm_read_byte((x)+(y))
 #endif //WITH_PGM_READ_HELPER
 
@@ -109,7 +125,42 @@ void ax_wdt_feed();
 #undef printf
 #endif
 //#define printf(...)  ets_printf(__VA_ARGS__)
+#undef PSTR // Defined in Arduino core
+#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
 #define PGM_VOID_P const void *
+
+#if (HAS_PROGMEM_FCNS==0)
+static inline void* memcpy_P(void* dest, PGM_VOID_P src, size_t count) {
+    const uint8_t* read = (const uint8_t*)(src);
+    uint8_t* write = (uint8_t*)(dest);
+
+    while (count)
+    {
+        *write++ = pgm_read_byte(read++);
+        count--;
+    }
+
+    return dest;
+}
+static inline int strlen_P(const char *str) {
+    int cnt = 0;
+    while (pgm_read_byte(str++)) cnt++;
+    return cnt;
+}
+static inline int memcmp_P(const void *a1, const void *b1, size_t len) {
+    const uint8_t* a = (const uint8_t*)(a1);
+    uint8_t* b = (uint8_t*)(b1);
+    for (size_t i=0; i<len; i++) {
+        uint8_t d = pgm_read_byte(a) - pgm_read_byte(b);
+        if (d) return d;
+        a++;
+        b++;
+    }
+    return 0;
+}
+#define strcpy_P(dst, src) do { static const char fstr[] PROGMEM = src; memcpy_P(dst, fstr, sizeof(src)); } while (0)
+#endif
+
 #define printf(fmt, ...) do { static const char fstr[] PROGMEM = fmt; char rstr[sizeof(fmt)]; memcpy_P(rstr, fstr, sizeof(rstr)); ets_printf(rstr, ##__VA_ARGS__); } while (0)
 
 // Copied from ets_sys.h to avoid compile warnings

--- a/ssl/os_port.h
+++ b/ssl/os_port.h
@@ -102,20 +102,6 @@ void ax_wdt_feed();
 #define ax_array_read_u8(x, y) x[y]
 #else
 
-static inline uint8_t pgm_read_byte(const void* addr) {
-  register uint32_t res;
-  __asm__("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */
-      "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */
-      "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */
-      "slli     %0, %0, 3\n"        /* Multiply offset by 8, yielding an offset in bits */
-      "ssr      %0\n"               /* Prepare to shift by offset (in bits) */
-      "srl      %0, %1\n"           /* Shift right; now the requested byte is the first one */
-      :"=r"(res), "=r"(addr)
-      :"1"(addr)
-      :);
-  return (uint8_t) res;     /* This masks the lower byte from the returned word */
-}
-
 #define ax_array_read_u8(x, y) pgm_read_byte((x)+(y))
 #endif //WITH_PGM_READ_HELPER
 
@@ -123,39 +109,8 @@ static inline uint8_t pgm_read_byte(const void* addr) {
 #undef printf
 #endif
 //#define printf(...)  ets_printf(__VA_ARGS__)
-#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
 #define PGM_VOID_P const void *
-static inline void* memcpy_P(void* dest, PGM_VOID_P src, size_t count) {
-    const uint8_t* read = (const uint8_t*)(src);
-    uint8_t* write = (uint8_t*)(dest);
-
-    while (count)
-    {
-        *write++ = pgm_read_byte(read++);
-        count--;
-    }
-
-    return dest;
-}
-static inline int strlen_P(const char *str) {
-    int cnt = 0;
-    while (pgm_read_byte(str++)) cnt++;
-    return cnt;
-}
-static inline int memcmp_P(const void *a1, const void *b1, size_t len) {
-    const uint8_t* a = (const uint8_t*)(a1);
-    uint8_t* b = (uint8_t*)(b1);
-    for (size_t i=0; i<len; i++) {
-        uint8_t d = pgm_read_byte(a) - pgm_read_byte(b);
-        if (d) return d;
-        a++;
-        b++;
-    }
-    return 0;
-}
-
 #define printf(fmt, ...) do { static const char fstr[] PROGMEM = fmt; char rstr[sizeof(fmt)]; memcpy_P(rstr, fstr, sizeof(rstr)); ets_printf(rstr, ##__VA_ARGS__); } while (0)
-#define strcpy_P(dst, src) do { static const char fstr[] PROGMEM = src; memcpy_P(dst, fstr, sizeof(src)); } while (0)
 
 // Copied from ets_sys.h to avoid compile warnings
 extern int ets_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));

--- a/ssl/x509.c
+++ b/ssl/x509.c
@@ -434,7 +434,7 @@ static bigint *sig_verify(BI_CTX *ctx, const uint8_t *sig, int sig_len, uint8_t 
         break;
     }
     if (sig_prefix)
-        hash_len = sig_prefix[sig_prefix_size - 1];
+        hash_len = pgm_read_byte(&sig_prefix[sig_prefix_size - 1]);
 
     /* check length (#A) */
     if (sig_len < 2 + 8 + 1 + sig_prefix_size + hash_len)


### PR DESCRIPTION
Several arrays were moved into flash but code was not changed to use
pgm_read_byte everywhere needed.  Fix, avoiding a crash on SSL cert
verification.

Also update makefile for the new libs and toolchain.